### PR TITLE
Rounding Error Bug

### DIFF
--- a/contracts/ConvergentCurvePool.sol
+++ b/contracts/ConvergentCurvePool.sol
@@ -228,7 +228,7 @@ contract ConvergentCurvePool is IMinimalSwapInfoPool, BalancerPoolToken {
         bytes32 poolId,
         address, // sender
         address recipient,
-        uint256[] calldata currentBalances,
+        uint256[] memory currentBalances,
         uint256,
         uint256 protocolSwapFee,
         bytes calldata userData
@@ -298,7 +298,7 @@ contract ConvergentCurvePool is IMinimalSwapInfoPool, BalancerPoolToken {
         bytes32 poolId,
         address,
         address recipient,
-        uint256[] calldata currentBalances,
+        uint256[] memory currentBalances,
         uint256,
         uint256 protocolSwapFee,
         bytes calldata userData


### PR DESCRIPTION
This PR fixes a rounding error bug which was triggered by 'calldata' arrays being immutable despite being castable to memory, upscaling the array fails in the onJoin and on onExit because of that.