### PR TITLE
Fix to ERC20 permit domainhash problem

### DIFF
--- a/contracts/InterestToken.sol
+++ b/contracts/InterestToken.sol
@@ -20,16 +20,52 @@ contract InterestToken is ERC20Permit, IInterestToken {
         string memory _strategySymbol,
         uint256 _timestamp,
         uint8 _decimals
-    ) ERC20Permit("Element Yield Token ", "eY:") {
+    )
+        ERC20Permit(
+            _processName("Element Yield Token ", _strategySymbol, _timestamp),
+            _processSymbol("eY:", _strategySymbol, _timestamp)
+        )
+    {
         tranche = ITranche(_tranche);
         _setupDecimals(_decimals);
-        // Write the strategySymbol and expiration time to name and symbol
+    }
+
+    /// @notice We use this function to add the date to the name string
+    /// @param _name start of the name
+    /// @param _strategySymbol the strategy symbol
+    /// @param _timestamp the unix second timestamp to be encoded and added to the end of the string
+    function _processName(
+        string memory _name,
+        string memory _strategySymbol,
+        uint256 _timestamp
+    ) internal returns (string memory) {
+        // Set the name in the super
+        name = _name;
+        // Use the library to write the rest
         DateString._encodeAndWriteTimestamp(_strategySymbol, _timestamp, name);
+        // load and return the name
+        return name;
+    }
+
+    /// @notice We use this function to add the date to the name string
+    /// @param _symbol start of the symbol
+    /// @param _strategySymbol the strategy symbol
+    /// @param _timestamp the unix second timestamp to be encoded and added to the end of the string
+    function _processSymbol(
+        string memory _symbol,
+        string memory _strategySymbol,
+        uint256 _timestamp
+    ) internal returns (string memory) {
+        // Set the symbol in the super
+        symbol = _symbol;
+        // Use the library to write the rest
         DateString._encodeAndWriteTimestamp(
             _strategySymbol,
             _timestamp,
             symbol
         );
+        // load and return the name
+        return symbol;
     }
 
     /// @dev Aliasing of the lookup method for the supply of yield tokens which

--- a/contracts/Tranche.sol
+++ b/contracts/Tranche.sol
@@ -46,14 +46,14 @@ contract Tranche is ERC20Permit, ITranche {
             address wpAddress,
             uint256 expiration,
             IInterestToken interestTokenTemp,
-            address dateLib
+            // solhint-disable-next-line
+            address unused
         ) = trancheFactory.getData();
         interestToken = interestTokenTemp;
 
         IWrappedPosition wpContract = IWrappedPosition(wpAddress);
         position = wpContract;
 
-        string memory strategySymbol = wpContract.symbol();
         // Store the immutable time variables
         unlockTimestamp = expiration;
         // We use local because immutables are not readable in construction
@@ -64,6 +64,22 @@ contract Tranche is ERC20Permit, ITranche {
         _underlyingDecimals = localUnderlyingDecimals;
         // And set this contract to have the same
         _setupDecimals(localUnderlyingDecimals);
+    }
+
+    /// @notice We override the optional extra construction function from ERC20 to change names
+    function _extraConstruction() internal override {
+        // Assume the caller is the Tranche factory and that this is called from constructor
+        // We have to do this double load because of the lack of flexibility in constructor ordering
+        ITrancheFactory trancheFactory = ITrancheFactory(msg.sender);
+        (
+            address wpAddress,
+            uint256 expiration,
+            // solhint-disable-next-line
+            IInterestToken unused,
+            address dateLib
+        ) = trancheFactory.getData();
+
+        string memory strategySymbol = IWrappedPosition(wpAddress).symbol();
 
         // Write the strategySymbol and expiration time to name and symbol
 

--- a/contracts/libraries/ERC20Permit.sol
+++ b/contracts/libraries/ERC20Permit.sol
@@ -49,6 +49,9 @@ abstract contract ERC20Permit is IERC20Permit {
         balanceOf[address(0)] = type(uint256).max;
         balanceOf[address(this)] = type(uint256).max;
 
+        // Optional extra state manipulation
+        extraConstruction();
+
         // Computes the EIP 712 domain separator which prevents user signed messages for
         // this contract to be replayed in other contracts.
         // https://eips.ethereum.org/EIPS/eip-712
@@ -64,6 +67,9 @@ abstract contract ERC20Permit is IERC20Permit {
             )
         );
     }
+
+    /// @notice An optional override function to execute and change state before immutable assignment
+    function _extraConstruction() internal virtual {}
 
     // --- Token ---
     /// @notice Allows a token owner to send tokens to another address

--- a/contracts/libraries/ERC20Permit.sol
+++ b/contracts/libraries/ERC20Permit.sol
@@ -50,7 +50,7 @@ abstract contract ERC20Permit is IERC20Permit {
         balanceOf[address(this)] = type(uint256).max;
 
         // Optional extra state manipulation
-        extraConstruction();
+        _extraConstruction();
 
         // Computes the EIP 712 domain separator which prevents user signed messages for
         // this contract to be replayed in other contracts.

--- a/test/convergentCurvePoolTests.ts
+++ b/test/convergentCurvePoolTests.ts
@@ -648,17 +648,11 @@ describe("ConvergentCurvePool", function () {
         ethers.utils.parseEther("0.1"),
         ethers.utils.defaultAbiCoder.encode(["uint256[]"], [lp_deposit])
       );
-      console.log(
-        BigNumber.from(bondAssetContract.address).lt(
-          BigNumber.from(baseAssetContract.address)
-        )
-      );
       // Check the returned fees
       expect(data[1][0]).to.be.eq(ethers.utils.parseUnits("1", BASE_DECIMALS));
       expect(data[1][1]).to.be.eq(
         ethers.utils.parseUnits("0.5", BOND_DECIMALS)
       );
-      console.log("passed check 1");
       // We run the call but state changing
       await aliasedVault.onJoinPool(
         poolId,

--- a/test/helpers/signatures.ts
+++ b/test/helpers/signatures.ts
@@ -4,7 +4,9 @@ import {
   toUtf8Bytes,
   solidityPack,
 } from "ethers/lib/utils";
-import { BigNumberish } from "ethers";
+import { BigNumberish, BigNumber } from "ethers";
+import { ethers } from "hardhat";
+import { ERC20Permit } from "typechain/ERC20Permit";
 
 export const PERMIT_TYPEHASH = keccak256(
   toUtf8Bytes(
@@ -38,4 +40,73 @@ export function getDigest(
       ]
     )
   );
+}
+
+export async function getPermitSignature(
+  token: ERC20Permit,
+  sourceAddr: string,
+  spenderAddr: string,
+  spenderAmount: BigNumberish,
+  version: string
+) {
+  // Load a json rpc signer
+  const signer = ethers.provider.getSigner(sourceAddr);
+
+  const name = await token.name();
+  const chainId = await signer.getChainId();
+  const domain = {
+    name: name,
+    version: version,
+    chainId: chainId,
+    verifyingContract: token.address,
+  };
+
+  const types = {
+    Permit: [
+      {
+        name: "owner",
+        type: "address",
+      },
+      {
+        name: "spender",
+        type: "address",
+      },
+      {
+        name: "value",
+        type: "uint256",
+      },
+      {
+        name: "nonce",
+        type: "uint256",
+      },
+      {
+        name: "deadline",
+        type: "uint256",
+      },
+    ],
+  };
+
+  const nonce = await token.nonces(sourceAddr);
+
+  const data = {
+    owner: sourceAddr,
+    spender: spenderAddr,
+    value: spenderAmount,
+    nonce: nonce,
+    deadline: ethers.constants.MaxUint256,
+  };
+
+  const sigStringPromise = signer._signTypedData(domain, types, data);
+  return sigStringPromise.then((value: string) => {
+    return parseSigString(value);
+  });
+}
+
+// Turns a 65 digit hex string prefixed by 0x into r, s, and v
+function parseSigString(signature: string) {
+  return {
+    r: signature.slice(0, 66),
+    s: "0x" + signature.slice(66, 130),
+    v: BigNumber.from("0x" + signature.slice(130)).toNumber(),
+  };
 }


### PR DESCRIPTION
The immutable ERC20 domain hash was wrong for tranche and yield token because they changed names after the ERC20Permit constructor.