### PR TITLE
Implement tranche hop zapper

### DIFF
--- a/contracts/zaps/ZapTrancheHop.sol
+++ b/contracts/zaps/ZapTrancheHop.sol
@@ -1,0 +1,116 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.0;
+
+import "../interfaces/IYearnVaultV2.sol";
+import "../libraries/Authorizable.sol";
+import "../interfaces/IERC20.sol";
+import "../interfaces/ITranche.sol";
+
+contract ZapTrancheHop is Authorizable {
+    // Store the accessibility state of the contract
+    bool public isFrozen = false;
+    // Tranche factory address for Tranche contract address derivation
+    address internal immutable _trancheFactory;
+    // Tranche bytecode hash for Tranche contract address derivation.
+    // This is constant as long as Tranche does not implement non-constant constructor arguments.
+    bytes32 internal immutable _trancheBytecodeHash;
+
+    /// @param __trancheFactory Address of the TrancheFactory contract
+    /// @param __trancheBytecodeHash Hash of the Tranche bytecode.
+    constructor(address __trancheFactory, bytes32 __trancheBytecodeHash)
+        Authorizable()
+    {
+        _authorize(msg.sender);
+        _trancheFactory = __trancheFactory;
+        _trancheBytecodeHash = __trancheBytecodeHash;
+    }
+
+    /// @dev Requires that the contract is not frozen
+    modifier notFrozen() {
+        require(!isFrozen, "Contract frozen");
+        _;
+    }
+
+    /// @dev Allows an authorized address to freeze or unfreeze this contract
+    /// @param _newState True for frozen and false for unfrozen
+    function setIsFrozen(bool _newState) external onlyAuthorized() {
+        isFrozen = _newState;
+    }
+
+    /// @notice Redeems Principal and Yield tokens and deposits the underlying assets received into
+    /// a new tranche. The target tranche must use the same underlying asset.
+    /// @param _underlying The underlying ERC20 token contract of the yearn vault.
+    /// @param _positionFrom The wrapped position of the originating tranche.
+    /// @param _expirationFrom The expiration timestamp of the originating tranche.
+    /// @param _positionTo The wrapped position of the target tranche.
+    /// @param _expirationTo The expiration timestamp of the target tranche.
+    /// @param _amountPt Amount of principal tokens to redeem and deposit into the new tranche.
+    /// @param _amountYt Amount of yield tokens to redeem and deposit into the new tranche.
+    /// @param _ptExpected The minimum amount of principal tokens to mint.
+    /// @return returns the minted amounts of principal and yield tokens (PT and YT)
+    function hopToTranche(
+        IERC20 _underlying,
+        address _positionFrom,
+        uint256 _expirationFrom,
+        address _positionTo,
+        uint256 _expirationTo,
+        uint256 _amountPt,
+        uint256 _amountYt,
+        uint256 _ptExpected
+    ) public returns (uint256, uint256) {
+        ITranche trancheFrom = _deriveTranche(
+            address(_positionFrom),
+            _expirationFrom
+        );
+        ITranche trancheTo = _deriveTranche(
+            address(_positionTo),
+            _expirationTo
+        );
+
+        if (_amountPt > 0) {
+            trancheFrom.transferFrom(msg.sender, address(this), _amountPt);
+            trancheFrom.approve(address(trancheFrom), _amountPt);
+            trancheFrom.withdrawPrincipal(_amountPt, _positionTo);
+        }
+
+        if (_amountYt > 0) {
+            IERC20 yt = IERC20(trancheFrom.interestToken());
+            yt.transferFrom(msg.sender, address(this), _amountYt);
+            yt.approve(address(trancheFrom), _amountYt);
+            trancheFrom.withdrawInterest(_amountYt, _positionTo);
+        }
+
+        uint256 balance = _underlying.balanceOf(_positionTo);
+
+        (uint256 ptMinted, uint256 ytMinted) = trancheTo.prefundedDeposit(
+            msg.sender
+        );
+
+        require(ytMinted >= balance, "Not enough YT minted");
+        require(ptMinted >= _ptExpected, "Not enough PT minted");
+        return (ptMinted, ytMinted);
+    }
+
+    /// @dev This internal function produces the deterministic create2
+    ///      address of the Tranche contract from a wrapped position contract and expiration
+    /// @param _position The wrapped position contract address
+    /// @param _expiration The expiration time of the tranche
+    /// @return The derived Tranche contract
+    function _deriveTranche(address _position, uint256 _expiration)
+        internal
+        virtual
+        view
+        returns (ITranche)
+    {
+        bytes32 salt = keccak256(abi.encodePacked(_position, _expiration));
+        bytes32 addressBytes = keccak256(
+            abi.encodePacked(
+                bytes1(0xff),
+                _trancheFactory,
+                salt,
+                _trancheBytecodeHash
+            )
+        );
+        return ITranche(address(uint160(uint256(addressBytes))));
+    }
+}

--- a/contracts/zaps/ZapTrancheHop.sol
+++ b/contracts/zaps/ZapTrancheHop.sol
@@ -47,6 +47,7 @@ contract ZapTrancheHop is Authorizable {
     /// @param _amountPt Amount of principal tokens to redeem and deposit into the new tranche.
     /// @param _amountYt Amount of yield tokens to redeem and deposit into the new tranche.
     /// @param _ptExpected The minimum amount of principal tokens to mint.
+    /// @param _ytExpected The minimum amount of yield tokens to mint.
     /// @return returns the minted amounts of principal and yield tokens (PT and YT)
     function hopToTranche(
         IERC20 _underlying,
@@ -56,7 +57,8 @@ contract ZapTrancheHop is Authorizable {
         uint256 _expirationTo,
         uint256 _amountPt,
         uint256 _amountYt,
-        uint256 _ptExpected
+        uint256 _ptExpected,
+        uint256 _ytExpected
     ) public returns (uint256, uint256) {
         ITranche trancheFrom = _deriveTranche(
             address(_positionFrom),
@@ -86,7 +88,10 @@ contract ZapTrancheHop is Authorizable {
             msg.sender
         );
 
-        require(ytMinted >= balance, "Not enough YT minted");
+        require(
+            ytMinted >= balance && ytMinted >= _ytExpected,
+            "Not enough YT minted"
+        );
         require(ptMinted >= _ptExpected, "Not enough PT minted");
         return (ptMinted, ytMinted);
     }

--- a/test/helpers/deployer.ts
+++ b/test/helpers/deployer.ts
@@ -19,6 +19,8 @@ import { InterestTokenFactory__factory } from "typechain/factories/InterestToken
 import { YVaultAssetProxy__factory } from "typechain/factories/YVaultAssetProxy__factory";
 import { ZapYearnShares__factory } from "typechain/factories/ZapYearnShares__factory";
 import { ZapYearnShares } from "typechain/ZapYearnShares";
+import { ZapTrancheHop__factory } from "typechain/factories/ZapTrancheHop__factory";
+import { ZapTrancheHop } from "typechain/ZapTrancheHop";
 import { IERC20 } from "typechain/IERC20";
 import { IWETH } from "typechain/IWETH";
 import { IYearnVault } from "typechain/IYearnVault";
@@ -75,6 +77,18 @@ export interface YearnShareZapInterface {
   yusdc: IYearnVault;
   position: YVaultAssetProxy;
   tranche: Tranche;
+}
+
+export interface TrancheHopInterface {
+  trancheHop: ZapTrancheHop;
+  signer: Signer;
+  usdc: IERC20;
+  yusdc: IYearnVault;
+  position: YVaultAssetProxy;
+  tranche1: Tranche;
+  tranche2: Tranche;
+  interestToken1: InterestToken;
+  interestToken2: InterestToken;
 }
 
 const deployTestWrappedPosition = async (signer: Signer, address: string) => {
@@ -334,5 +348,68 @@ export async function loadYearnShareZapFixture() {
     yusdc,
     position,
     tranche,
+  };
+}
+
+export async function loadTrancheHopFixture(toAuth: string) {
+  const usdcAddress = "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48";
+  const yusdcAddress = "0x5f18C75AbDAe578b483E5F43f12a39cF75b973a9";
+  const [signer] = await ethers.getSigners();
+
+  const usdc = IERC20__factory.connect(usdcAddress, signer);
+  const yusdc = IYearnVault__factory.connect(yusdcAddress, signer);
+  const position = await deployYasset(
+    signer,
+    yusdc.address,
+    usdc.address,
+    "Element Yearn USDC",
+    "eyUSDC"
+  );
+  // deploy and fetch tranche contract
+  const trancheFactory = await deployTrancheFactory(signer);
+  await trancheFactory.deployTranche(1e10, position.address);
+  await trancheFactory.deployTranche(2e10, position.address);
+  const eventFilter = trancheFactory.filters.TrancheCreated(null, null, null);
+  const events = await trancheFactory.queryFilter(eventFilter);
+  const trancheAddress1 = events[0] && events[0].args && events[0].args[0];
+  const trancheAddress2 = events[1] && events[1].args && events[1].args[0];
+
+  const tranche1 = Tranche__factory.connect(trancheAddress1, signer);
+  const tranche2 = Tranche__factory.connect(trancheAddress2, signer);
+
+  const interestTokenAddress1 = await tranche1.interestToken();
+  const interestToken1 = InterestToken__factory.connect(
+    interestTokenAddress1,
+    signer
+  );
+  const interestTokenAddress2 = await tranche2.interestToken();
+  const interestToken2 = InterestToken__factory.connect(
+    interestTokenAddress2,
+    signer
+  );
+  // Setup the proxy
+  const bytecodehash = ethers.utils.solidityKeccak256(
+    ["bytes"],
+    [data.bytecode]
+  );
+
+  const deployer = new ZapTrancheHop__factory(signer);
+  const trancheHop = await deployer.deploy(
+    trancheFactory.address,
+    bytecodehash
+  );
+
+  await trancheHop.connect(signer).authorize(toAuth);
+
+  return {
+    trancheHop,
+    signer,
+    usdc,
+    yusdc,
+    position,
+    tranche1,
+    tranche2,
+    interestToken1,
+    interestToken2,
   };
 }

--- a/test/zapTrancheHopTest.ts
+++ b/test/zapTrancheHopTest.ts
@@ -1,0 +1,190 @@
+import { expect } from "chai";
+import { Signer, BigNumber, BigNumberish } from "ethers";
+import { ethers, waffle } from "hardhat";
+import { loadTrancheHopFixture, TrancheHopInterface } from "./helpers/deployer";
+import { createSnapshot, restoreSnapshot } from "./helpers/snapshots";
+import { advanceTime } from "./helpers/time";
+import { impersonate, stopImpersonating } from "./helpers/impersonate";
+
+const { provider } = waffle;
+
+describe("zapTrancheHop", () => {
+  let users: { user: Signer; address: string }[];
+  let fixture: TrancheHopInterface;
+
+  // send `amount` of shares directly to the yearn vault simulating interest.
+  async function yearnInterestSim(amount: BigNumberish) {
+    const usdcWhaleAddress = "0xAe2D4617c862309A3d75A0fFB358c7a5009c673F";
+    impersonate(usdcWhaleAddress);
+    const lpSigner = await ethers.provider.getSigner(usdcWhaleAddress);
+    await fixture.usdc
+      .connect(lpSigner)
+      .transfer(fixture.yusdc.address, amount);
+  }
+
+  before(async () => {
+    // snapshot initial state
+    await createSnapshot(provider);
+
+    // begin to populate the user array by assigning each index a signer
+    users = ((await ethers.getSigners()) as Signer[]).map(function (user) {
+      return { user, address: "" };
+    });
+
+    // finish populating the user array by assigning each index a signer address
+    await Promise.all(
+      users.map(async (userInfo) => {
+        const { user } = userInfo;
+        userInfo.address = await user.getAddress();
+      })
+    );
+
+    fixture = await loadTrancheHopFixture(users[1].address);
+    // get USDC
+    const usdcWhaleAddress = "0xAe2D4617c862309A3d75A0fFB358c7a5009c673F";
+    impersonate(usdcWhaleAddress);
+    const usdcWhale = await ethers.provider.getSigner(usdcWhaleAddress);
+    await fixture.usdc.connect(usdcWhale).transfer(users[1].address, 2e11); // 200k usdc
+    stopImpersonating(usdcWhaleAddress);
+  });
+  after(async () => {
+    // revert back to initial state after all tests pass
+    await restoreSnapshot(provider);
+  });
+  beforeEach(async () => {
+    await createSnapshot(provider);
+  });
+  afterEach(async () => {
+    await restoreSnapshot(provider);
+  });
+
+  describe("hopToTranche", () => {
+    beforeEach(async () => {
+      await createSnapshot(provider);
+      await fixture.usdc
+        .connect(users[1].user)
+        .approve(fixture.tranche1.address, 1e11);
+      await fixture.tranche1
+        .connect(users[1].user)
+        .deposit(1e11, users[1].address);
+      // add some interest so YTs are redeemable
+      yearnInterestSim(1000000000000);
+      // move first tranche to expiration
+      advanceTime(provider, 1e10);
+    });
+
+    afterEach(async () => {
+      await restoreSnapshot(provider);
+    });
+    it("should revert if the contract is frozen", async () => {
+      await fixture.trancheHop.connect(users[1].user).setIsFrozen(true);
+      const tx = fixture.trancheHop
+        .connect(users[1].user)
+        .hopToTranche(
+          fixture.usdc.address,
+          fixture.position.address,
+          0,
+          fixture.position.address,
+          0,
+          0,
+          0,
+          0,
+          0
+        );
+
+      await expect(tx).to.be.revertedWith("Contract frozen");
+    });
+    it("should fail to hop with insufficient PT minted", async () => {
+      const ptBalanceT1 = await fixture.tranche1.balanceOf(users[1].address);
+      const ytBalanceT1 = await fixture.interestToken1.balanceOf(
+        users[1].address
+      );
+
+      await fixture.tranche1
+        .connect(users[1].user)
+        .approve(fixture.trancheHop.address, ptBalanceT1);
+      await fixture.interestToken1
+        .connect(users[1].user)
+        .approve(fixture.trancheHop.address, ytBalanceT1);
+
+      const tx = fixture.trancheHop
+        .connect(users[1].user)
+        .hopToTranche(
+          fixture.usdc.address,
+          fixture.position.address,
+          1e10,
+          fixture.position.address,
+          2e10,
+          ptBalanceT1,
+          ytBalanceT1,
+          1e12,
+          1
+        );
+      await expect(tx).to.be.revertedWith("Not enough PT minted");
+    });
+    it("should fail to hop with insufficient YT minted", async () => {
+      const ptBalanceT1 = await fixture.tranche1.balanceOf(users[1].address);
+      const ytBalanceT1 = await fixture.interestToken1.balanceOf(
+        users[1].address
+      );
+
+      await fixture.tranche1
+        .connect(users[1].user)
+        .approve(fixture.trancheHop.address, ptBalanceT1);
+      await fixture.interestToken1
+        .connect(users[1].user)
+        .approve(fixture.trancheHop.address, ytBalanceT1);
+
+      const tx = fixture.trancheHop
+        .connect(users[1].user)
+        .hopToTranche(
+          fixture.usdc.address,
+          fixture.position.address,
+          1e10,
+          fixture.position.address,
+          2e10,
+          ptBalanceT1,
+          ytBalanceT1,
+          1,
+          1e12
+        );
+      await expect(tx).to.be.revertedWith("Not enough YT minted");
+    });
+    it("should correctly hop tranches", async () => {
+      const ptBalanceT1 = await fixture.tranche1.balanceOf(users[1].address);
+      const ytBalanceT1 = await fixture.interestToken1.balanceOf(
+        users[1].address
+      );
+
+      await fixture.tranche1
+        .connect(users[1].user)
+        .approve(fixture.trancheHop.address, ptBalanceT1);
+      await fixture.interestToken1
+        .connect(users[1].user)
+        .approve(fixture.trancheHop.address, ytBalanceT1);
+
+      await fixture.trancheHop
+        .connect(users[1].user)
+        .hopToTranche(
+          fixture.usdc.address,
+          fixture.position.address,
+          1e10,
+          fixture.position.address,
+          2e10,
+          ptBalanceT1,
+          ytBalanceT1,
+          1,
+          1
+        );
+
+      const ptBalanceT2 = await fixture.tranche2.balanceOf(users[1].address);
+      const ytBalanceT2 = await fixture.interestToken2.balanceOf(
+        users[1].address
+      );
+
+      // no interest accumulated in new tranche so no PT discounting
+      expect(ptBalanceT2).to.equal(ytBalanceT2);
+      expect(ptBalanceT2).to.be.at.least(1);
+    });
+  });
+});


### PR DESCRIPTION
Tranche hop allows moving from one tranche to another within the same wrapped position. 

This Zapper should reduce the impact of Yearn withdrawals by pairing each withdrawal with a matching deposit of the same size in the same transaction. This Zapper can only be used within the same wrapped position. or between wrappedPosition of the same underlying asset.