### PR TITLE
Fixing inconcsistency with token naming

### DIFF
--- a/contracts/Tranche.sol
+++ b/contracts/Tranche.sol
@@ -39,7 +39,7 @@ contract Tranche is ERC20Permit, ITranche {
     event SpeedBumpHit(uint256 timestamp);
 
     /// @notice Constructs this contract
-    constructor() ERC20Permit("Principal Token ", "eP:") {
+    constructor() ERC20Permit("Element Principal Token ", "eP:") {
         // Assume the caller is the Tranche factory.
         ITrancheFactory trancheFactory = ITrancheFactory(msg.sender);
         (

--- a/test/trancheTest.ts
+++ b/test/trancheTest.ts
@@ -923,7 +923,7 @@ describe("Tranche", () => {
         "eP:TestWrappedPosition:20-NOV-86-GMT"
       );
       expect(await fixture.tranche.name()).to.be.eq(
-        "Principal Token TestWrappedPosition:20-NOV-86-GMT"
+        "Element Principal Token TestWrappedPosition:20-NOV-86-GMT"
       );
     });
   });


### PR DESCRIPTION
Yield Tokens are named something like: `Element Yield Token eyUSDC:09-JUN-21-GMT`.  Principal Tokens don't have the Element prefix.  This PR fixes this