### PR TITLE
Added a new asset proxy to support yearn vault 4.2

### DIFF
--- a/contracts/YVaultAssetProxy.sol
+++ b/contracts/YVaultAssetProxy.sol
@@ -277,6 +277,7 @@ contract YVaultAssetProxy is WrappedPosition {
     /// @dev WARNING - In yearn 0.3.1 - 0.3.5 this is an exact match for deposit logic
     ///                but not withdraw logic in versions 0.3.2-0.3.5. In versions 0.4.0+
     ///                it is not a match for yearn deposit ratios.
+    /// @return The converted output of either underlying or yearn shares
     function _yearnDepositConverter(uint256 amount, bool sharesIn)
         internal
         virtual

--- a/contracts/YVaultAssetProxy.sol
+++ b/contracts/YVaultAssetProxy.sol
@@ -46,13 +46,13 @@ contract YVaultAssetProxy is WrappedPosition {
             "Inconsistent decimals"
         );
         // We check that this is a compatible yearn version
-        versionCheck(IYearnVault(vault_));
+        _versionCheck(IYearnVault(vault_));
     }
 
     /// @notice An override-able version checking function, reverts if the vault has the wrong version
     /// @param _vault The yearn vault address
     /// @dev This function can be overridden by an inheriting upgrade contract
-    function versionCheck(IYearnVault _vault) internal virtual view {
+    function _versionCheck(IYearnVault _vault) internal virtual view {
         string memory apiVersion = _vault.apiVersion();
         require(
             _stringEq(apiVersion, "0.3.0") ||

--- a/contracts/YVaultAssetProxy.sol
+++ b/contracts/YVaultAssetProxy.sol
@@ -48,12 +48,12 @@ contract YVaultAssetProxy is WrappedPosition {
 
         string memory apiVersion = IYearnVault(vault_).apiVersion();
         require(
-            stringEq(apiVersion, "0.3.0") ||
-                stringEq(apiVersion, "0.3.1") ||
-                stringEq(apiVersion, "0.3.2") ||
-                stringEq(apiVersion, "0.3.3") ||
-                stringEq(apiVersion, "0.3.4") ||
-                stringEq(apiVersion, "0.3.5"),
+            _stringEq(apiVersion, "0.3.0") ||
+                _stringEq(apiVersion, "0.3.1") ||
+                _stringEq(apiVersion, "0.3.2") ||
+                _stringEq(apiVersion, "0.3.3") ||
+                _stringEq(apiVersion, "0.3.4") ||
+                _stringEq(apiVersion, "0.3.5"),
             "Unsupported Version"
         );
     }
@@ -62,7 +62,7 @@ contract YVaultAssetProxy is WrappedPosition {
     /// @param s1 string one
     /// @param s2 string two
     /// @return bool weather they are equal
-    function stringEq(string memory s1, string memory s2)
+    function _stringEq(string memory s1, string memory s2)
         internal
         pure
         returns (bool)

--- a/contracts/YVaultV4AssetProxy.sol
+++ b/contracts/YVaultV4AssetProxy.sol
@@ -47,14 +47,14 @@ contract YVaultV4AssetProxy is WrappedPosition {
         );
 
         string memory apiVersion = IYearnVault(vault_).apiVersion();
-        require(stringEq(apiVersion, "0.4.2"), "Unsupported Version");
+        require(_stringEq(apiVersion, "0.4.2"), "Unsupported Version");
     }
 
     /// @notice checks if two strings are equal
     /// @param s1 string one
     /// @param s2 string two
     /// @return bool weather they are equal
-    function stringEq(string memory s1, string memory s2)
+    function _stringEq(string memory s1, string memory s2)
         internal
         pure
         returns (bool)

--- a/contracts/YVaultV4AssetProxy.sol
+++ b/contracts/YVaultV4AssetProxy.sol
@@ -37,6 +37,7 @@ contract YVaultV4AssetProxy is YVaultAssetProxy {
     /// @param sharesIn true to convert from yearn shares to underlying, false to convert from
     ///                 underlying to yearn shares
     /// @dev WARNING - Fails for 0.3.2-0.3.5, please only use with 0.4.2
+    /// @return The converted output of either underlying or yearn shares
     function _yearnDepositConverter(uint256 amount, bool sharesIn)
         internal
         override

--- a/contracts/YVaultV4AssetProxy.sol
+++ b/contracts/YVaultV4AssetProxy.sol
@@ -26,7 +26,7 @@ contract YVaultV4AssetProxy is YVaultAssetProxy {
     /// @notice Overrides the version checking to check for 0.4.2 instead
     /// @param _vault The yearn vault address
     /// @dev This function can be overridden by an inheriting upgrade contract
-    function versionCheck(IYearnVault _vault) internal override view {
+    function _versionCheck(IYearnVault _vault) internal override view {
         string memory apiVersion = _vault.apiVersion();
         require(_stringEq(apiVersion, "0.4.2"), "Unsupported Version");
     }

--- a/contracts/YVaultV4AssetProxy.sol
+++ b/contracts/YVaultV4AssetProxy.sol
@@ -5,28 +5,13 @@ pragma solidity ^0.8.0;
 
 import "./interfaces/IERC20.sol";
 import "./interfaces/IYearnVault.sol";
-import "./WrappedPosition.sol";
+import "./YVaultAssetProxy.sol";
 
 /// @author Element Finance
 /// @title Yearn Vault Asset Proxy
-contract YVaultV4AssetProxy is WrappedPosition {
-    IYearnVault public immutable vault;
-    uint8 public immutable vaultDecimals;
-
-    // This contract allows deposits to a reserve which can
-    // be used to short circuit the deposit process and save gas
-
-    // The following mapping tracks those non-transferable deposits
-    mapping(address => uint256) public reserveBalances;
-    // These variables store the token balances of this contract and
-    // should be packed by solidity into a single slot.
-    uint128 public reserveUnderlying;
-    uint128 public reserveShares;
-    // This is the total amount of reserve deposits
-    uint256 public reserveSupply;
-
-    /// @notice Constructs this contract and stores needed data
-    /// @param vault_ The yearn v2 vault
+contract YVaultV4AssetProxy is YVaultAssetProxy {
+    /// @notice Constructs this contract by calling into the super constructor
+    /// @param vault_ The yearn v2 vault, must be version 0.4.2
     /// @param _token The underlying token.
     ///               This token should revert in the event of a transfer failure.
     /// @param _name The name of the token created
@@ -36,223 +21,37 @@ contract YVaultV4AssetProxy is WrappedPosition {
         IERC20 _token,
         string memory _name,
         string memory _symbol
-    ) WrappedPosition(_token, _name, _symbol) {
-        vault = IYearnVault(vault_);
-        _token.approve(vault_, type(uint256).max);
-        uint8 localVaultDecimals = IERC20(vault_).decimals();
-        vaultDecimals = localVaultDecimals;
-        require(
-            uint8(_token.decimals()) == localVaultDecimals,
-            "Inconsistent decimals"
-        );
+    ) YVaultAssetProxy(vault_, _token, _name, _symbol) {}
 
-        string memory apiVersion = IYearnVault(vault_).apiVersion();
+    /// @notice Overrides the version checking to check for 0.4.2 instead
+    /// @param _vault The yearn vault address
+    /// @dev This function can be overridden by an inheriting upgrade contract
+    function versionCheck(IYearnVault _vault) internal override view {
+        string memory apiVersion = _vault.apiVersion();
         require(_stringEq(apiVersion, "0.4.2"), "Unsupported Version");
     }
 
-    /// @notice checks if two strings are equal
-    /// @param s1 string one
-    /// @param s2 string two
-    /// @return bool weather they are equal
-    function _stringEq(string memory s1, string memory s2)
-        internal
-        pure
-        returns (bool)
-    {
-        bytes32 h1 = keccak256(abi.encodePacked(s1));
-        bytes32 h2 = keccak256(abi.encodePacked(s2));
-        return (h1 == h2);
-    }
-
-    /// @notice This function allows a user to deposit to the reserve
-    ///      Note - there's no incentive to do so. You could earn some
-    ///      interest but less interest than yearn. All deposits use
-    ///      the underlying token.
-    /// @param _amount The amount of underlying to deposit
-    function reserveDeposit(uint256 _amount) external {
-        // Transfer from user, note variable 'token' is the immutable
-        // inherited from the abstract WrappedPosition contract.
-        token.transferFrom(msg.sender, address(this), _amount);
-        // Load the reserves
-        (uint256 localUnderlying, uint256 localShares) = _getReserves();
-        // Calculate the total reserve value
-        uint256 totalValue = localUnderlying;
-        uint256 pricePerShare = _pricePerShare();
-        totalValue += ((localShares * pricePerShare) / 10**vaultDecimals);
-        // If this is the first deposit we need different logic
-        uint256 localReserveSupply = reserveSupply;
-        uint256 mintAmount;
-        if (localReserveSupply == 0) {
-            // If this is the first mint the tokens are exactly the supplied underlying
-            mintAmount = _amount;
-        } else {
-            // Otherwise we mint the proportion that this increases the value held by this contract
-            mintAmount = (localReserveSupply * _amount) / totalValue;
-        }
-
-        // This hack means that the contract will never have zero balance of underlying
-        // which levels the gas expenditure of the transfer to this contract. Permanently locks
-        // the smallest possible unit of the underlying.
-        if (localUnderlying == 0 && localShares == 0) {
-            _amount -= 1;
-        }
-        // Set the reserves that this contract has more underlying
-        _setReserves(localUnderlying + _amount, localShares);
-        // Note that the sender has deposited and increase reserveSupply
-        reserveBalances[msg.sender] += mintAmount;
-        reserveSupply = localReserveSupply + mintAmount;
-    }
-
-    /// @notice This function allows a holder of reserve balance to withdraw their share
-    /// @param _amount The number of reserve shares to withdraw
-    function reserveWithdraw(uint256 _amount) external {
-        // Remove 'amount' from the balances of the sender. Because this is 8.0 it will revert on underflow
-        reserveBalances[msg.sender] -= _amount;
-        // We load the reserves
-        (uint256 localUnderlying, uint256 localShares) = _getReserves();
-        uint256 localReserveSupply = reserveSupply;
-        // Then we calculate the proportion of the shares to redeem
-        uint256 userShares = (localShares * _amount) / localReserveSupply;
-        // First we withdraw the proportion of shares tokens belonging to the caller
-        uint256 freedUnderlying = vault.withdraw(userShares, address(this), 0);
-        // We calculate the amount of underlying to send
-        uint256 userUnderlying = (localUnderlying * _amount) /
-            localReserveSupply;
-
-        // We then store the updated reserve amounts
-        _setReserves(
-            localUnderlying - userUnderlying,
-            localShares - userShares
-        );
-        // We note a reduction in local supply
-        reserveSupply = localReserveSupply - _amount;
-
-        // We send the redemption underlying to the caller
-        // Note 'token' is an immutable from shares
-        token.transfer(msg.sender, freedUnderlying + userUnderlying);
-    }
-
-    /// @notice Makes the actual deposit into the yearn vault
-    ///         Tries to use the local balances before depositing
-    /// @return Tuple (the shares minted, amount underlying used)
-    function _deposit() internal override returns (uint256, uint256) {
-        //Load reserves
-        (uint256 localUnderlying, uint256 localShares) = _getReserves();
-        // Get the amount deposited
-        uint256 amount = token.balanceOf(address(this)) - localUnderlying;
-        // fixing for the fact there's an extra underlying
-        if (localUnderlying != 0 || localShares != 0) {
-            amount -= 1;
-        }
-        // Calculate the amount of shares the amount deposited is worth
-        uint256 pricePerShare = _pricePerShare();
-        uint256 neededShares = (amount * pricePerShare) / 10**vaultDecimals;
-
-        // If we have enough in local reserves we don't call out for deposits
-        if (localShares > neededShares) {
-            // We set the reserves
-            _setReserves(localUnderlying + amount, localShares - neededShares);
-            // And then we short circuit execution and return
-            return (neededShares, amount);
-        }
-        // Deposit and get the shares that were minted to this
-        uint256 shares = vault.deposit(localUnderlying + amount, address(this));
-
-        // calculate the user share
-        uint256 userShare = (amount * shares) / (localUnderlying + amount);
-
-        // We set the reserves
-        _setReserves(0, localShares + shares - userShare);
-        // Return the amount of shares the user has produced, and the amount used for it.
-        return (userShare, amount);
-    }
-
-    /// @notice Withdraw the number of shares and will short circuit if it can
-    /// @param _shares The number of shares to withdraw
-    /// @param _destination The address to send the output funds
-    /// @param _underlyingPerShare The possibly precomputed underlying per share
-    function _withdraw(
-        uint256 _shares,
-        address _destination,
-        uint256 _underlyingPerShare
-    ) internal override returns (uint256) {
-        // If we do not have it we load the price per share
-        if (_underlyingPerShare == 0) {
-            _underlyingPerShare = _pricePerShare();
-        }
-        // We load the reserves
-        (uint256 localUnderlying, uint256 localShares) = _getReserves();
-        // Calculate the amount of shares the amount deposited is worth
-        uint256 needed = _underlying(_shares);
-        // If we have enough underlying we don't have to actually withdraw
-        if (needed < localUnderlying) {
-            // We set the reserves to be the new reserves
-            _setReserves(localUnderlying - needed, localShares + _shares);
-            // Then transfer needed underlying to the destination
-            // 'token' is an immutable in WrappedPosition
-            token.transfer(_destination, needed);
-            // Short circuit and return
-            return (needed);
-        }
-        // If we don't have enough local reserves we do the actual withdraw
-        // Withdraws shares from the vault. Max loss is set at 100% as
-        // the minimum output value is enforced by the calling
-        // function in the WrappedPosition contract.
-        uint256 amountReceived = vault.withdraw(
-            _shares + localShares,
-            address(this),
-            10000
-        );
-
-        // calculate the user share
-        uint256 userShare = (_shares * amountReceived) /
-            (localShares + _shares);
-
-        _setReserves(localUnderlying + amountReceived - userShare, 0);
-        // Transfer the underlying to the destination 'token' is an immutable in WrappedPosition
-        token.transfer(_destination, userShare);
-        // Return the amount of underlying
-        return userShare;
-    }
-
-    /// @notice Get the underlying amount of tokens per shares given
-    /// @param _amount The amount of shares you want to know the value of
-    /// @return Value of shares in underlying token
-    function _underlying(uint256 _amount)
+    /// @notice Converts an input of shares to it's output of underlying or an input
+    ///      of underlying to an output of shares, using yearn 's deposit pricing
+    /// @param amount the amount of input, shares if 'sharesIn == true' underlying if not
+    /// @param sharesIn true to convert from yearn shares to underlying, false to convert from
+    ///                 underlying to yearn shares
+    /// @dev WARNING - Fails for 0.3.2-0.3.5, please only use with 0.4.2
+    function _yearnDepositConverter(uint256 amount, bool sharesIn)
         internal
         override
         view
         returns (uint256)
     {
-        return (_amount * _pricePerShare()) / (10**vaultDecimals);
-    }
-
-    /// @notice Get the price per share in the vault
-    /// @return The price per share in units of underlying;
-    function _pricePerShare() internal view returns (uint256) {
-        return vault.pricePerShare();
-    }
-
-    /// @notice Function to reset approvals for the proxy
-    function approve() external {
-        token.approve(address(vault), 0);
-        token.approve(address(vault), type(uint256).max);
-    }
-
-    /// @notice Helper to get the reserves with one sload
-    /// @return Tuple (reserve underlying, reserve shares)
-    function _getReserves() internal view returns (uint256, uint256) {
-        return (uint256(reserveUnderlying), uint256(reserveShares));
-    }
-
-    /// @notice Helper to set reserves using one sstore
-    /// @param _newReserveUnderlying The new reserve of underlying
-    /// @param _newReserveShares The new reserve of wrapped position shares
-    function _setReserves(
-        uint256 _newReserveUnderlying,
-        uint256 _newReserveShares
-    ) internal {
-        reserveUnderlying = uint128(_newReserveUnderlying);
-        reserveShares = uint128(_newReserveShares);
+        // Load the yearn price per share
+        uint256 pricePerShare = vault.pricePerShare();
+        // If we are converted shares to underlying
+        if (sharesIn) {
+            // If the input is shares we multiply by the price per share
+            return (pricePerShare * amount) / 10**vaultDecimals;
+        } else {
+            // If the input is in underlying we divide by price per share
+            return (amount * 10**vaultDecimals) / pricePerShare;
+        }
     }
 }

--- a/contracts/YVaultV4AssetProxy.sol
+++ b/contracts/YVaultV4AssetProxy.sol
@@ -51,7 +51,7 @@ contract YVaultV4AssetProxy is YVaultAssetProxy {
             return (pricePerShare * amount) / 10**vaultDecimals;
         } else {
             // If the input is in underlying we divide by price per share
-            return (amount * 10**vaultDecimals) / pricePerShare;
+            return (amount * 10**vaultDecimals) / (pricePerShare + 1);
         }
     }
 }

--- a/contracts/interfaces/IYearnVault.sol
+++ b/contracts/interfaces/IYearnVault.sol
@@ -22,4 +22,6 @@ interface IYearnVault is IERC20 {
     function totalSupply() external view returns (uint256);
 
     function totalAssets() external view returns (uint256);
+
+    function apiVersion() external view returns (string memory);
 }

--- a/contracts/test/MockERC20YearnVault.sol
+++ b/contracts/test/MockERC20YearnVault.sol
@@ -1,5 +1,5 @@
 pragma solidity ^0.8.0;
-import "../interfaces/IYearnVaultV2.sol";
+import "../interfaces/IYearnVault.sol";
 import "../libraries/Authorizable.sol";
 import "../libraries/ERC20Permit.sol";
 
@@ -36,6 +36,10 @@ contract MockERC20YearnVault is IYearnVault, Authorizable, ERC20Permit {
         // 6 hours in blocks
         // 6*60*60 ~= 1e6 / 46
         lockedProfitDegradation = (DEGRADATION_COEFFICIENT * 46) / 1e6;
+    }
+
+    function apiVersion() external override pure returns (string memory) {
+        return ("0.3.2");
     }
 
     /**

--- a/contracts/test/TestYVault.sol
+++ b/contracts/test/TestYVault.sol
@@ -23,13 +23,18 @@ contract TestYVault is ERC20PermitWithSupply {
         external
         returns (uint256)
     {
-        uint256 _shares = (_amount * (10**decimals)) / pricePerShare(); // calculate shares
+        uint256 _shares;
+        if (totalSupply == 0) {
+            _shares = _amount;
+        } else {
+            _shares = (_amount * (10**decimals)) / pricePerShare(); // calculate shares
+        }
         IERC20(token).transferFrom(msg.sender, address(this), _amount); // pull deposit from sender
         _mint(destination, _shares); // mint shares for sender
         return _shares;
     }
 
-    function apiVersion() external pure returns (string memory) {
+    function apiVersion() external virtual pure returns (string memory) {
         return ("0.3.2");
     }
 

--- a/contracts/test/TestYVault.sol
+++ b/contracts/test/TestYVault.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.0;
 
 import "../interfaces/IERC20.sol";
-import "../interfaces/IYearnVaultV2.sol";
+import "../interfaces/IYearnVault.sol";
 
 import "../libraries/ERC20PermitWithSupply.sol";
 
@@ -27,6 +27,10 @@ contract TestYVault is ERC20PermitWithSupply {
         IERC20(token).transferFrom(msg.sender, address(this), _amount); // pull deposit from sender
         _mint(destination, _shares); // mint shares for sender
         return _shares;
+    }
+
+    function apiVersion() external pure returns (string memory) {
+        return ("0.3.2");
     }
 
     function withdraw(

--- a/contracts/test/TestYVaultV4.sol
+++ b/contracts/test/TestYVaultV4.sol
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.0;
+
+import "./TestYVault.sol";
+
+// NOTE - the test y vault uses the formula of 0.4.2 and versions prior to
+//        0.3.2, so when we test the YAssetProxyV4 we actually want the same logic
+//        except that we want to return a diff version.
+//        The subtly of 0.3.2 - 0.3.5 yearn vaults is tested in the mainnet tests.
+
+contract TestYVaultV4 is TestYVault {
+    constructor(address _token, uint8 _decimals)
+        TestYVault(_token, _decimals)
+    {}
+
+    function apiVersion() external override pure returns (string memory) {
+        return ("0.4.2");
+    }
+}

--- a/contracts/zaps/ZapTrancheHop.sol
+++ b/contracts/zaps/ZapTrancheHop.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.0;
 
-import "../interfaces/IYearnVaultV2.sol";
+import "../interfaces/IYearnVault.sol";
 import "../libraries/Authorizable.sol";
 import "../interfaces/IERC20.sol";
 import "../interfaces/ITranche.sol";

--- a/contracts/zaps/ZapYearnShares.sol
+++ b/contracts/zaps/ZapYearnShares.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.0;
 
-import "../interfaces/IYearnVaultV2.sol";
+import "../interfaces/IYearnVault.sol";
 import "../libraries/Authorizable.sol";
 import "../interfaces/IERC20.sol";
 import "../interfaces/ITranche.sol";

--- a/test/wrappedPositionTest.ts
+++ b/test/wrappedPositionTest.ts
@@ -1,9 +1,12 @@
 import { expect } from "chai";
-import { Signer } from "ethers";
+import { BigNumber, Signer } from "ethers";
 import { ethers, waffle } from "hardhat";
 
 import { FixtureInterface, loadFixture } from "./helpers/deployer";
 import { createSnapshot, restoreSnapshot } from "./helpers/snapshots";
+
+import { TestYVaultV4 } from "typechain/TestYVaultV4";
+import { YVaultV4AssetProxy } from "typechain/YVaultV4AssetProxy";
 
 const { provider } = waffle;
 
@@ -44,6 +47,29 @@ describe("Wrapped Position", () => {
   after(async () => {
     // revert back to initial state after all tests pass
     await restoreSnapshot(provider);
+  });
+  describe("Version locked deployments", () => {
+    it("Wont deploy YAssetProxy with a v4 yearn vault", async () => {
+      // Deploy a mock yearn v4
+      const mockYearnV4Factory = await ethers.getContractFactory(
+        "TestYVaultV4"
+      );
+      const yVaultV4 = await mockYearnV4Factory.deploy(
+        fixture.usdc.address,
+        await fixture.usdc.decimals()
+      );
+      // Attempt to deploy a non v4 wp on it
+      const yearnWPFactory = await ethers.getContractFactory(
+        "YVaultAssetProxy"
+      );
+      const tx = yearnWPFactory.deploy(
+        yVaultV4.address,
+        fixture.usdc.address,
+        "mock yearn",
+        "my"
+      );
+      await expect(tx).to.be.revertedWith("Unsupported Version");
+    });
   });
   describe("balanceOfUnderlying", () => {
     beforeEach(async () => {
@@ -214,6 +240,93 @@ describe("Wrapped Position", () => {
       currentBalance = await fixture.usdc.balanceOf(users[0].address);
       expect(currentBalance).to.be.eq(balanceStart.add(999999).add(1e6));
       expect(await fixture.position.reserveShares()).to.be.eq(7272728);
+    });
+  });
+  // We test explicity only the functionality changes in V4 not the whole
+  // contract
+  describe("Wrapped Yearn Vault v4 upgrade", async () => {
+    let vaultV4: TestYVaultV4;
+    let wpV4: YVaultV4AssetProxy;
+
+    before(async () => {
+      // Deploy a mock yearn v4
+      const mockYearnV4Factory = await ethers.getContractFactory(
+        "TestYVaultV4"
+      );
+      // TODO - Update so that the ethers factories play nice with types
+      vaultV4 = (await mockYearnV4Factory.deploy(
+        fixture.usdc.address,
+        await fixture.usdc.decimals()
+      )) as TestYVaultV4;
+      // Deploy a wrapped position
+      const wpFactory = await ethers.getContractFactory("YVaultV4AssetProxy");
+      wpV4 = (await wpFactory.deploy(
+        vaultV4.address,
+        fixture.usdc.address,
+        "mock yearn v4",
+        "test"
+      )) as YVaultV4AssetProxy;
+      // set approvals for accounts
+      await fixture.usdc.approve(wpV4.address, ethers.constants.MaxUint256);
+      await fixture.usdc
+        .connect(users[1].user)
+        .approve(wpV4.address, ethers.constants.MaxUint256);
+      // deposit into the yearn vault so there's a supply
+      await fixture.usdc.approve(vaultV4.address, ethers.constants.MaxUint256);
+      await vaultV4.deposit(1e6, users[0].address);
+    });
+
+    beforeEach(async () => {
+      await createSnapshot(provider);
+    });
+    afterEach(async () => {
+      // revert back to initial state after all tests pass
+      await restoreSnapshot(provider);
+    });
+
+    it("Won't deploy on a v3 wrapped position", async () => {
+      const wpFactory = await ethers.getContractFactory("YVaultAssetProxy");
+      const tx = wpFactory.deploy(
+        vaultV4.address,
+        fixture.usdc.address,
+        "mock yearn v4",
+        "test"
+      );
+      await expect(tx).to.be.revertedWith("Unsupported Version");
+    });
+
+    it("Reserve deposits", async () => {
+      // First deposit inits
+      await wpV4.reserveDeposit(1e6);
+      // Check that we got shares
+      let balance = await wpV4.reserveBalances(users[0].address);
+      expect(balance).to.be.eq(BigNumber.from(1e6));
+      // Do a deposit to convert to shares
+      await wpV4.connect(users[1].user).deposit(users[1].address, 1e6);
+      console.log(await fixture.usdc.balanceOf(vaultV4.address));
+      // We want to change deposit rate
+      await fixture.usdc.transfer(vaultV4.address, 5e5);
+      // Now we deposit and check the price of deposit
+      await wpV4.reserveDeposit(1e6);
+      // Check the new balance
+      balance = await wpV4.reserveBalances(users[0].address);
+      // Magic number from rounding error on deposits
+      expect(balance).to.be.eq(BigNumber.from(1857144));
+    });
+
+    it("withdraws with the correct ratio", async () => {
+      await wpV4.deposit(users[0].address, 1e6);
+      // Check that we got shares
+      const balance = await wpV4.balanceOf(users[0].address);
+      expect(balance).to.be.eq(BigNumber.from(1e6));
+      // We want to change withdraw rate
+      await fixture.usdc.transfer(vaultV4.address, 5e5);
+      // withdraw
+      const balanceBefore = await fixture.usdc.balanceOf(users[0].address);
+      await wpV4.withdraw(users[0].address, balance, 0);
+      const balanceAfter = await fixture.usdc.balanceOf(users[0].address);
+      // check the withdraw amount
+      expect(balanceAfter.sub(balanceBefore)).to.be.eq(125e4);
     });
   });
 });


### PR DESCRIPTION
Two primary changes:

1. I version locked the asset proxy for yearn which supports the major version 3 and added api version methods to our testing contracts so the tests can pass version locking.
2. I created a copy of the major version 3 vault which is updated to be compatible with changes in yearn 0.4.2 vaults. Namely it changes the deposit ratios to match the new deposit ratios from yearn.