### PR TITLE
allow 0.4.3 yearn vault version

### DIFF
--- a/contracts/YVaultV4AssetProxy.sol
+++ b/contracts/YVaultV4AssetProxy.sol
@@ -28,7 +28,10 @@ contract YVaultV4AssetProxy is YVaultAssetProxy {
     /// @dev This function can be overridden by an inheriting upgrade contract
     function _versionCheck(IYearnVault _vault) internal override view {
         string memory apiVersion = _vault.apiVersion();
-        require(_stringEq(apiVersion, "0.4.2"), "Unsupported Version");
+        require(
+            _stringEq(apiVersion, "0.4.2") || _stringEq(apiVersion, "0.4.3"),
+            "Unsupported Version"
+        );
     }
 
     /// @notice Converts an input of shares to it's output of underlying or an input


### PR DESCRIPTION
The newer version modifies the definition of `total assets` to exclude any locked funds in the context of `_sharesForAmount()`

before  `_sharesForAmount()` would return zero if `totalAssets == 0`
now it will return zero if  `totalAssets - lockedProfit == 0`

This is just to cover an edge case and I don't think it affects our integration