### PR TITLE
Fix comment warning user of yvault compatibility

### DIFF
--- a/contracts/YVaultAssetProxy.sol
+++ b/contracts/YVaultAssetProxy.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// WARNING: This has been validated for yearn vaults up to version 0.2.11.
+// WARNING: This has been validated for yearn vaults up to version 0.3.5.
 // Using this code with any later version can be unsafe.
 pragma solidity ^0.8.0;
 


### PR DESCRIPTION
The comment was referring to the vyper version instead of the yvault version