### PR TITLE
Create validator for deployed contracts

### DIFF
--- a/contracts/DeploymentValidator.sol
+++ b/contracts/DeploymentValidator.sol
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.0;
+
+import "./libraries/Authorizable.sol";
+import "./interfaces/IDeploymentValidator.sol";
+
+contract DeploymentValidator is IDeploymentValidator, Authorizable {
+    mapping(address => bool) public wrappedPositions;
+    mapping(address => bool) public pools;
+    mapping(bytes32 => bool) public pairs;
+
+    constructor(address _owner) {
+        _authorize(_owner);
+    }
+
+    function validateWPAddress(address wrappedPosition)
+        external
+        override
+        onlyAuthorized
+    {
+        wrappedPositions[wrappedPosition] = true;
+    }
+
+    function validatePoolAddress(address pool)
+        external
+        override
+        onlyAuthorized
+    {
+        pools[pool] = true;
+    }
+
+    function validateAddresses(address wrappedPosition, address pool)
+        external
+        override
+        onlyAuthorized
+    {
+        bytes32 data = keccak256(abi.encodePacked(wrappedPosition, pool));
+        pairs[data] = true;
+    }
+
+    function checkWPValidation(address wrappedPosition)
+        external
+        view
+        override
+        returns (bool)
+    {
+        return wrappedPositions[wrappedPosition];
+    }
+
+    function checkPoolValidation(address pool)
+        external
+        view
+        override
+        returns (bool)
+    {
+        return pools[pool];
+    }
+
+    function checkPairValidation(address wrappedPosition, address pool)
+        external
+        view
+        override
+        returns (bool)
+    {
+        bytes32 data = keccak256(abi.encodePacked(wrappedPosition, pool));
+        return pairs[data];
+    }
+}

--- a/contracts/DeploymentValidator.sol
+++ b/contracts/DeploymentValidator.sol
@@ -23,7 +23,7 @@ contract DeploymentValidator is IDeploymentValidator, Authorizable {
     /// @notice adds a wrapped position address to the mapping
     /// @param wrappedPosition The wrapped position contract address
     function validateWPAddress(address wrappedPosition)
-        external
+        public
         override
         onlyAuthorized
     {
@@ -33,11 +33,7 @@ contract DeploymentValidator is IDeploymentValidator, Authorizable {
 
     /// @notice adds a wrapped position address to the mapping
     /// @param pool the pool contract address
-    function validatePoolAddress(address pool)
-        external
-        override
-        onlyAuthorized
-    {
+    function validatePoolAddress(address pool) public override onlyAuthorized {
         // add address to mapping to indicating it was deployed by Element
         pools[pool] = true;
     }
@@ -50,7 +46,11 @@ contract DeploymentValidator is IDeploymentValidator, Authorizable {
         override
         onlyAuthorized
     {
-        // has together the contract addresses
+        // add to pool validation mapping
+        validatePoolAddress(pool);
+        // add to wp validation mapping
+        validateWPAddress(wrappedPosition);
+        // hash together the contract addresses
         bytes32 data = keccak256(abi.encodePacked(wrappedPosition, pool));
         // add the hashed pair into the mapping
         pairs[data] = true;

--- a/contracts/DeploymentValidator.sol
+++ b/contracts/DeploymentValidator.sol
@@ -5,39 +5,60 @@ import "./libraries/Authorizable.sol";
 import "./interfaces/IDeploymentValidator.sol";
 
 contract DeploymentValidator is IDeploymentValidator, Authorizable {
+    // a mapping of wrapped position contracts deployed by Element
     mapping(address => bool) public wrappedPositions;
+    // a mapping of pool contracts deployed by Element
     mapping(address => bool) public pools;
+    // a mapping of wrapped position + pool pairs that are deployed by Element
+    // we keccak256 hash these tuples together to serve as the mapping keys
     mapping(bytes32 => bool) public pairs;
 
+    /// @notice Constructs this contract and stores needed data
+    /// @param _owner The contract owner authorized to validate addresses
     constructor(address _owner) {
+        // authorize the owner address to be able to execute the validations
         _authorize(_owner);
     }
 
+    /// @notice adds a wrapped position address to the mapping
+    /// @param wrappedPosition The wrapped position contract address
     function validateWPAddress(address wrappedPosition)
         external
         override
         onlyAuthorized
     {
+        // add address to mapping to indicating it was deployed by Element
         wrappedPositions[wrappedPosition] = true;
     }
 
+    /// @notice adds a wrapped position address to the mapping
+    /// @param pool the pool contract address
     function validatePoolAddress(address pool)
         external
         override
         onlyAuthorized
     {
+        // add address to mapping to indicating it was deployed by Element
         pools[pool] = true;
     }
 
+    /// @notice adds a wrapped position + pool pair of addresses to mapping
+    /// @param wrappedPosition the wrapped position contract address
+    /// @param pool the pool contract address
     function validateAddresses(address wrappedPosition, address pool)
         external
         override
         onlyAuthorized
     {
+        // has together the contract addresses
         bytes32 data = keccak256(abi.encodePacked(wrappedPosition, pool));
+        // add the hashed pair into the mapping
         pairs[data] = true;
     }
 
+    /// @notice checks to see if the address has been validated
+    /// @param wrappedPosition the address to check
+    /// @return true if validated, false if not
     function checkWPValidation(address wrappedPosition)
         external
         view
@@ -47,6 +68,9 @@ contract DeploymentValidator is IDeploymentValidator, Authorizable {
         return wrappedPositions[wrappedPosition];
     }
 
+    /// @notice checks to see if the address has been validated
+    /// @param pool the address to check
+    /// @return true if validated, false if not
     function checkPoolValidation(address pool)
         external
         view
@@ -56,6 +80,10 @@ contract DeploymentValidator is IDeploymentValidator, Authorizable {
         return pools[pool];
     }
 
+    /// @notice checks to see if the pair of addresses have been validated
+    /// @param wrappedPosition the wrapped position address to check
+    /// @param pool the pool address to check
+    /// @return true if validated, false if not
     function checkPairValidation(address wrappedPosition, address pool)
         external
         view

--- a/contracts/interfaces/IDeploymentValidator.sol
+++ b/contracts/interfaces/IDeploymentValidator.sol
@@ -8,11 +8,15 @@ interface IDeploymentValidator {
 
     function validateAddresses(address wrappedPosition, address pool) external;
 
-    function checkWPValidation(address wrappedPosition) external returns (bool);
+    function checkWPValidation(address wrappedPosition)
+        external
+        view
+        returns (bool);
 
-    function checkPoolValidation(address pool) external returns (bool);
+    function checkPoolValidation(address pool) external view returns (bool);
 
     function checkPairValidation(address wrappedPosition, address pool)
         external
+        view
         returns (bool);
 }

--- a/contracts/interfaces/IDeploymentValidator.sol
+++ b/contracts/interfaces/IDeploymentValidator.sol
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.0;
+
+interface IDeploymentValidator {
+    function validateWPAddress(address wrappedPosition) external;
+
+    function validatePoolAddress(address pool) external;
+
+    function validateAddresses(address wrappedPosition, address pool) external;
+
+    function checkWPValidation(address wrappedPosition) external returns (bool);
+
+    function checkPoolValidation(address pool) external returns (bool);
+
+    function checkPairValidation(address wrappedPosition, address pool)
+        external
+        returns (bool);
+}

--- a/test/deploymentValidatorTest.ts
+++ b/test/deploymentValidatorTest.ts
@@ -7,7 +7,7 @@ import { boolean } from "hardhat/internal/core/params/argumentTypes";
 
 const { provider } = waffle;
 
-describe.only("Deployment Validator", () => {
+describe("Deployment Validator", () => {
   let deploymentValidator: DeploymentValidator;
   let signers: SignerWithAddress[];
 

--- a/test/deploymentValidatorTest.ts
+++ b/test/deploymentValidatorTest.ts
@@ -70,6 +70,13 @@ describe("Deployment Validator", () => {
         .checkPoolValidation(mockPoolAddress);
       expect(result).to.be.equal(true);
     });
+    it("validate pool fails for unauthorized owner", async () => {
+      const mockPoolAddress = "0x814C447a9F58A2b823504Fe2775bA48c843925B6";
+      const tx = deploymentValidator
+        .connect(signers[1])
+        .validatePoolAddress(mockPoolAddress);
+      await expect(tx).to.be.revertedWith("Sender not Authorized");
+    });
     it("validate pool returns false unregistered address", async () => {
       const mockPoolAddress = "0x8dc82c95B8901Db35390Aa4096B643d7724F278D";
       const result = await deploymentValidator
@@ -85,10 +92,28 @@ describe("Deployment Validator", () => {
       await deploymentValidator
         .connect(signers[0])
         .validateAddresses(mockWPAddress, mockPoolAddress);
-      const result = await deploymentValidator
+      // check pair validation
+      const result1 = await deploymentValidator
         .connect(signers[0])
         .checkPairValidation(mockWPAddress, mockPoolAddress);
-      expect(result).to.be.equal(true);
+      expect(result1).to.be.equal(true);
+      // check individual mapping validation
+      const result2 = await deploymentValidator
+        .connect(signers[0])
+        .checkWPValidation(mockWPAddress);
+      expect(result2).to.be.equal(true);
+      const result3 = await deploymentValidator
+        .connect(signers[0])
+        .checkPoolValidation(mockPoolAddress);
+      expect(result3).to.be.equal(true);
+    });
+    it("validate pool/wp pair fails for unauthorized owner", async () => {
+      const mockWPAddress = "0x6F643Ba6894D8C50c476A3539e1D1690B2194018";
+      const mockPoolAddress = "0x814C447a9F58A2b823504Fe2775bA48c843925B6";
+      const tx = deploymentValidator
+        .connect(signers[1])
+        .validateAddresses(mockWPAddress, mockPoolAddress);
+      await expect(tx).to.be.revertedWith("Sender not Authorized");
     });
     it("validation returns false unregistered addresses", async () => {
       const mockWPAddress = "0xb47E7a1fD90630CfC0868d90Cb8F518578010cFe";

--- a/test/deploymentValidatorTest.ts
+++ b/test/deploymentValidatorTest.ts
@@ -1,0 +1,102 @@
+import { ethers, waffle } from "hardhat";
+import { expect } from "chai";
+import { DeploymentValidator } from "typechain/DeploymentValidator";
+import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
+import { createSnapshot, restoreSnapshot } from "./helpers/snapshots";
+import { boolean } from "hardhat/internal/core/params/argumentTypes";
+
+const { provider } = waffle;
+
+describe.only("Deployment Validator", () => {
+  let deploymentValidator: DeploymentValidator;
+  let signers: SignerWithAddress[];
+
+  before(async () => {
+    await createSnapshot(provider);
+    signers = await ethers.getSigners();
+
+    const deployer = await ethers.getContractFactory(
+      "DeploymentValidator",
+      signers[0]
+    );
+    deploymentValidator = await deployer.deploy(signers[0].address);
+  });
+
+  after(async () => {
+    await restoreSnapshot(provider);
+  });
+
+  beforeEach(async () => {
+    await createSnapshot(provider);
+  });
+  afterEach(async () => {
+    await restoreSnapshot(provider);
+  });
+
+  describe("validate wrapped position addresses", () => {
+    it("validates wp address correctly", async () => {
+      const mockWPAddress = "0x814C447a9F58A2b823504Fe2775bA48c843925B6";
+      await deploymentValidator
+        .connect(signers[0])
+        .validateWPAddress(mockWPAddress);
+      const result = await deploymentValidator
+        .connect(signers[0])
+        .checkWPValidation(mockWPAddress);
+      expect(result).to.be.equal(true);
+    });
+    it("validate wp fails for unauthorized owner", async () => {
+      const mockWPAddress = "0x814C447a9F58A2b823504Fe2775bA48c843925B6";
+      const tx = deploymentValidator
+        .connect(signers[1])
+        .validateWPAddress(mockWPAddress);
+      await expect(tx).to.be.revertedWith("Sender not Authorized");
+    });
+    it("validate wp returns false unregistered address", async () => {
+      const mockWPAddress = "0x8dc82c95B8901Db35390Aa4096B643d7724F278D";
+      const result = await deploymentValidator
+        .connect(signers[0])
+        .checkWPValidation(mockWPAddress);
+      expect(result).to.be.equal(false);
+    });
+  });
+  describe("validate pool addresses", () => {
+    it("validates pool address correctly", async () => {
+      const mockPoolAddress = "0x5941DB4d6C500C4FFa57c359eE0C55c6b41D0b61";
+      await deploymentValidator
+        .connect(signers[0])
+        .validatePoolAddress(mockPoolAddress);
+      const result = await deploymentValidator
+        .connect(signers[0])
+        .checkPoolValidation(mockPoolAddress);
+      expect(result).to.be.equal(true);
+    });
+    it("validate pool returns false unregistered address", async () => {
+      const mockPoolAddress = "0x8dc82c95B8901Db35390Aa4096B643d7724F278D";
+      const result = await deploymentValidator
+        .connect(signers[0])
+        .checkPoolValidation(mockPoolAddress);
+      expect(result).to.be.equal(false);
+    });
+  });
+  describe("validate wp/pool pair addresses", () => {
+    it("validates addresses correctly", async () => {
+      const mockWPAddress = "0x6F643Ba6894D8C50c476A3539e1D1690B2194018";
+      const mockPoolAddress = "0xB59C7597228fEBccEC3dC0571a7Ee39A26E316B9";
+      await deploymentValidator
+        .connect(signers[0])
+        .validateAddresses(mockWPAddress, mockPoolAddress);
+      const result = await deploymentValidator
+        .connect(signers[0])
+        .checkPairValidation(mockWPAddress, mockPoolAddress);
+      expect(result).to.be.equal(true);
+    });
+    it("validation returns false unregistered addresses", async () => {
+      const mockWPAddress = "0xb47E7a1fD90630CfC0868d90Cb8F518578010cFe";
+      const mockPoolAddress = "0x4294005520c453EB8Fa66F53042cfC79707855c4";
+      const result = await deploymentValidator
+        .connect(signers[0])
+        .checkPairValidation(mockWPAddress, mockPoolAddress);
+      expect(result).to.be.equal(false);
+    });
+  });
+});


### PR DESCRIPTION
Creates a contract that can validate contract addresses for wrapped positions and pools deployed by Element. Functions add contract addresses to a mapping, either for WP's, pools, or a pair of both.

After this is reviewed and merged, next step is to add mods to deployment scripts to run these validations on deployment